### PR TITLE
Replacing reference to deprecated PluginManagerHolder

### DIFF
--- a/src/groovy/grails/plugin/scopedproxy/reload/filters/ReloadedScopedBeanFiltersReloader.groovy
+++ b/src/groovy/grails/plugin/scopedproxy/reload/filters/ReloadedScopedBeanFiltersReloader.groovy
@@ -18,7 +18,7 @@ package grails.plugin.scopedproxy.reload.filters
 import grails.plugin.scopedproxy.reload.ScopedBeanReloadListener
 import org.slf4j.LoggerFactory
 import org.codehaus.groovy.grails.plugins.web.filters.FiltersConfigArtefactHandler
-import org.codehaus.groovy.grails.plugins.PluginManagerHolder
+import grails.util.Holders
 import org.codehaus.groovy.grails.plugins.web.filters.FilterConfig
 
 class ReloadedScopedBeanFiltersReloader implements ScopedBeanReloadListener {
@@ -79,13 +79,13 @@ class ReloadedScopedBeanFiltersReloader implements ScopedBeanReloadListener {
 	}
 
 	protected getFiltersPlugin() {
-		PluginManagerHolder.pluginManager.getGrailsPlugin('filters')
+		Holders.pluginManager.getGrailsPlugin('filters')
 	}
 	
 	protected triggerFiltersReload(Class triggeringFiltersClass) {
 		GroovySystem.metaClassRegistry.removeMetaClass(FilterConfig)
 		filtersPlugin.doWithDynamicMethods(grailsApplication.mainContext)
-		PluginManagerHolder.pluginManager.informOfClassChange(triggeringFiltersClass)
+		Holders.pluginManager.informOfClassChange(triggeringFiltersClass)
 	}
 	
 	private static final log = LoggerFactory.getLogger(ReloadedScopedBeanFiltersReloader)

--- a/src/groovy/grails/plugin/scopedproxy/reload/request/RequestScopedBeanReloadSessionPurger.groovy
+++ b/src/groovy/grails/plugin/scopedproxy/reload/request/RequestScopedBeanReloadSessionPurger.groovy
@@ -18,7 +18,6 @@ package grails.plugin.scopedproxy.reload.request
 import grails.plugin.scopedproxy.reload.ScopedBeanReloadListener
 import org.slf4j.LoggerFactory
 import org.codehaus.groovy.grails.plugins.web.filters.FiltersConfigArtefactHandler
-import org.codehaus.groovy.grails.plugins.PluginManagerHolder
 import org.codehaus.groovy.grails.plugins.web.filters.FilterConfig
 import grails.plugin.scopedproxy.ScopedProxyUtils as SPU
 


### PR DESCRIPTION
org.codehaus.groovy.grails.plugins.PluginManagerHolder was deprecated a while ago and has been completely removed in 2.4, causing the compilation to fail with 2.4.x. I replaced it with the recommended replacement (grails.util.Holders) as per http://grails.org/doc/2.4.x/guide/upgradingFrom23.html.
